### PR TITLE
Added middleware, global exception handler

### DIFF
--- a/lithuanian-language-learning-tool/Components/Pages/Error.razor
+++ b/lithuanian-language-learning-tool/Components/Pages/Error.razor
@@ -1,0 +1,3 @@
+@page "/Error"
+<h1>Oops! Something went wrong.</h1>
+<p>An unexpected error occurred. Please try again later.</p>

--- a/lithuanian-language-learning-tool/Components/TaskUploadPrompt.razor
+++ b/lithuanian-language-learning-tool/Components/TaskUploadPrompt.razor
@@ -39,11 +39,11 @@
         var uri = NavigationManager.Uri.ToLower();
         if ((uri.Contains("/rasybos/uzduotys")) || (uri.Contains("/rasybos/pasirinkimai/temos")) || (uri.Contains("/rasybos/pasirinkimai/randomizuoti")))
         {
-            taskType = "punctuation";
+            taskType = "spelling";
         }
         else if ((uri.Contains("/skyrybos/uzduotys")) || (uri.Contains("/skyrybos/pasirinkimai/temos")) || (uri.Contains("/skyrybos/pasirinkimai/uzduotys")))
         {
-            taskType = "spelling";
+            taskType = "punctation";
         }
     }
 
@@ -75,11 +75,6 @@
         catch (lithuanian_language_learning_tool.Exceptions.TaskUploadException ex)
         {
             errorMessage = $"Klaida įkeliant failą: {ex.Message}";
-            LogException(ex);
-        }
-        catch (Exception ex)
-        {
-            errorMessage = $"Nenumatyta klaida: {ex.Message}";
             LogException(ex);
         }
     }
@@ -128,7 +123,7 @@
                 }
                 else if (taskType == "spelling")
                 {
-                    if (!options.All(opt => opt.Length == 1 && char.IsLetter(opt[0])))
+                    if (!options.All(opt => opt.Length >= 1 && char.IsLetter(opt[0])))
                     {
                         throw new TaskUploadException("Netinkama Options struktūra: rašybos užduotyse leidžiamos tik raidės.");
                     }

--- a/lithuanian-language-learning-tool/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/lithuanian-language-learning-tool/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Http;
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace lithuanian_language_learning_tool.Middleware
+{
+    public class GlobalExceptionHandlerMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public GlobalExceptionHandlerMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (Exception ex)
+            {
+                await HandleExceptionAsync(context, ex);
+            }
+        }
+
+        private static Task HandleExceptionAsync(HttpContext context, Exception exception)
+        {
+            var logPath = Path.Combine("logs", "errors.log");
+            Directory.CreateDirectory("logs");
+
+            // Log the exception details
+            using (var writer = new StreamWriter(logPath, append: true))
+            {
+                writer.WriteLine($"[{DateTime.Now}] {exception.Message}");
+                writer.WriteLine(exception.StackTrace);
+                writer.WriteLine("--------------------------------------------------");
+            }
+
+            // Prepare a JSON response
+            var response = new
+            {
+                error = "An error occurred while processing your request.",
+                details = exception.Message // Avoid exposing too much info in production
+            };
+
+            context.Response.ContentType = "application/json";
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            return context.Response.WriteAsync(JsonSerializer.Serialize(response));
+        }
+    }
+}

--- a/lithuanian-language-learning-tool/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/lithuanian-language-learning-tool/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -32,7 +32,6 @@ namespace lithuanian_language_learning_tool.Middleware
             var logPath = Path.Combine("logs", "errors.log");
             Directory.CreateDirectory("logs");
 
-            // Log the exception details
             using (var writer = new StreamWriter(logPath, append: true))
             {
                 writer.WriteLine($"[{DateTime.Now}] {exception.Message}");
@@ -40,11 +39,10 @@ namespace lithuanian_language_learning_tool.Middleware
                 writer.WriteLine("--------------------------------------------------");
             }
 
-            // Prepare a JSON response
             var response = new
             {
                 error = "An error occurred while processing your request.",
-                details = exception.Message // Avoid exposing too much info in production
+                details = exception.Message
             };
 
             context.Response.ContentType = "application/json";

--- a/lithuanian-language-learning-tool/Program.cs
+++ b/lithuanian-language-learning-tool/Program.cs
@@ -10,9 +10,9 @@ using System;
 using lithuanian_language_learning_tool.Data;
 using Microsoft.Extensions.Configuration;
 using lithuanian_language_learning_tool.Models;
+using lithuanian_language_learning_tool.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
-
 
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
@@ -21,7 +21,6 @@ if (builder.Environment.IsDevelopment())
 {
     builder.Configuration.AddUserSecrets<Program>();
 }
-
 
 builder.Services.AddAuthentication(options =>
 {
@@ -55,12 +54,18 @@ builder.Services.AddScoped<ITaskService<SpellingTask>, TaskService<SpellingTask>
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
+app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
+
 if (!app.Environment.IsDevelopment())
 {
-    app.UseExceptionHandler("/Error", createScopeForErrors: true);
+    app.UseExceptionHandler("/Error");
     app.UseHsts();
 }
+
+app.MapGet("/trigger-exception", () =>
+{
+    throw new Exception("This is a test exception!");
+});
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();
@@ -79,6 +84,5 @@ app.MapGet("/logout", async (HttpContext context) =>
     await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
     return Results.Redirect("/");
 });
-
 
 app.Run();


### PR DESCRIPTION
added global exception handler, only works in cs files tho, 
The issue arises because Blazor components handle exceptions differently than typical middleware pipelines in ASP.NET Core. Exceptions thrown in Razor component code (like your login.razor) are not caught by the global exception handler middleware because these exceptions occur in the Blazor rendering lifecycle, not in the HTTP request pipeline.